### PR TITLE
chore(backend): add example environment configuration file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# rename .env.example to .env and fill in the values
+
+# secret key for the application
+#   this should be a long, random string
+#   used for session management and security
+#   DO NOT SHARE THIS KEY
+SECRET_KEY = ''
+
+# ip blacklist
+IP_BLACKLIST = ['']
+
+# set default directories
+    # set with the path where the application will run,
+    # otherwise the application will not run via wsgi
+    DEFAULT_DIR = "c:\\cde"
+    # used for debugging purposes, can be the same as DEFAULT_DIR
+    DEBUG_DIR = "c:\\cde"
+
+# database
+    # credentials for the database connection (via odbc)
+    DB_USER = 'username;password'
+    DB_API = 'ip:port'
+
+    # directory (path from .db files created by the application)
+    DEBUG_DB_PATH = 'dbg_cde.db'
+    DB_PATH = 'cde.db'
+
+# temporary password for new users
+#   this password is used for the first login of new users
+#   it should be changed after the first login
+#   DO NOT SHARE THIS PASSWORD
+TEMP_PASSWORD = 'cde123'
+
+# telegram api bot credentials
+TLG_BOT_TOKEN = ''
+TLG_CHAT_ID = ''


### PR DESCRIPTION
Introduces .env.example with placeholders for secret keys, database credentials, directory paths, and Telegram bot settings to guide users in setting up their environment variables.